### PR TITLE
Add writeup for dont-you-love-banners challenge

### DIFF
--- a/cryptography/dont-you-love-banners/README.md
+++ b/cryptography/dont-you-love-banners/README.md
@@ -1,0 +1,4 @@
+# Claiming Challenge: dont-you-love-banners
+
+I am claiming this cryptography challenge from PicoCTF 2025.  
+The solution will be submitted in a second pull request.


### PR DESCRIPTION
This commit adds the initial README for the "dont-you-love-banners" challenge in the Cryptography category of PicoCTF 2024.

